### PR TITLE
add error messages when lacking permissions for commands

### DIFF
--- a/Gameserver/src/ffa/java/com/minecrafttas/tasbattle/ffa/managers/KitManager.java
+++ b/Gameserver/src/ffa/java/com/minecrafttas/tasbattle/ffa/managers/KitManager.java
@@ -209,9 +209,11 @@ public class KitManager extends LobbyManager implements CommandHandler {
 	 */
 	@Override
 	public boolean onCommand(CommandSender sender, @NotNull Command command, @NotNull String label, String[] args) {
-		if (!sender.isOp())
+		if (!sender.isOp()) {
+			sender.sendMessage(MiniMessage.miniMessage().deserialize("<aqua>»</aqua> <red>Insufficient permissions</red>"));
 			return true;
-		
+		}
+
 		// print help
 		if (args.length == 0) {
 			sender.sendMessage(MiniMessage.miniMessage().deserialize("<aqua>»</aqua> <gray>/ffa <green>save <aqua>\\<name> \\<material> \\<description></aqua></green></gray>"));

--- a/Gameserver/src/main/java/com/minecrafttas/tasbattle/TASBattleGameserver.java
+++ b/Gameserver/src/main/java/com/minecrafttas/tasbattle/TASBattleGameserver.java
@@ -11,6 +11,7 @@ import com.minecrafttas.tasbattle.stats.StatsManager;
 import io.papermc.paper.event.player.AsyncChatEvent;
 import lombok.Getter;
 import lombok.SneakyThrows;
+import net.kyori.adventure.text.minimessage.MiniMessage;
 import org.apache.commons.lang3.tuple.Pair;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
@@ -90,7 +91,7 @@ public class TASBattleGameserver extends JavaPlugin implements CommandExecutor, 
 		if (sender.isOp())
 			Runtime.getRuntime().halt(0);
 		else
-			sender.sendMessage(Bukkit.getServer().permissionMessage());
+			sender.sendMessage(MiniMessage.miniMessage().deserialize("<aqua>»</aqua> <red>Insufficient permissions</red>"));
 
 		return true;
 	}

--- a/Gameserver/src/main/java/com/minecrafttas/tasbattle/managers/TickrateChanger.java
+++ b/Gameserver/src/main/java/com/minecrafttas/tasbattle/managers/TickrateChanger.java
@@ -121,8 +121,10 @@ public class TickrateChanger implements PluginMessageListener, Listener, Command
 	 */
 	@Override
 	public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-		if (!sender.isOp() || args.length != 1)
+		if (!sender.isOp() || args.length != 1) {
+			sender.sendMessage(MiniMessage.miniMessage().deserialize("<aqua>»</aqua> <red>Insufficient permissions</red>"));
 			return true;
+		}
 
 		try {
 			// parse and update tickrate

--- a/Lobby/src/main/java/com/minecrafttas/tasbattle/managers/TickrateChanger.java
+++ b/Lobby/src/main/java/com/minecrafttas/tasbattle/managers/TickrateChanger.java
@@ -121,8 +121,10 @@ public class TickrateChanger implements PluginMessageListener, Listener, Command
 	 */
 	@Override
 	public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
-		if (!sender.isOp() || args.length != 1)
+		if (!sender.isOp() || args.length != 1) {
+			sender.sendMessage(MiniMessage.miniMessage().deserialize("<aqua>»</aqua> <red>Insufficient permissions</red>"));
 			return true;
+		}
 
 		try {
 			// parse and update tickrate


### PR DESCRIPTION
Uses a minimessage red error message instead of Bukkit.getServer.permissionMessage intentionally, for consistency with the messages that are sent when you can actually use the commands